### PR TITLE
Replace `sys.exit` with ValueError

### DIFF
--- a/partition/kk.py
+++ b/partition/kk.py
@@ -3,7 +3,6 @@ try:
     from Queue import LifoQueue
 except ImportError:
     from queue import LifoQueue
-import sys
 
 __all__ = ['kk']
 

--- a/partition/kk.py
+++ b/partition/kk.py
@@ -5,9 +5,12 @@ except ImportError:
     from queue import LifoQueue
 import sys
 
-def kk(number_list, group_len=2): # Karmarkar-Karp heuristic
+__all__ = ['kk']
+
+def kk(number_list, group_len=2):
+    """Karmarkar-Karp heuristic"""
     if group_len != 2:
-        sys.exit("unsupported group length: %s for KK algorithm!" % group_len)
+        raise ValueError("unsupported group length: %s for KK algorithm!" % group_len)
     pairs = LifoQueue()
     group1, group2 = [], []
     heap = [(-1*i, i) for i in number_list]


### PR DESCRIPTION
`sys.exit` is extremely frustrating to debug, please replace it with a regular error in order to provide stack trace and a proper error handling mechanism to work.